### PR TITLE
Replace Jupiter Swap URL with higher rate limits

### DIFF
--- a/scripts/chain/solana/trade.js
+++ b/scripts/chain/solana/trade.js
@@ -19,12 +19,12 @@ const SOL_MINT = 'So11111111111111111111111111111111111111112';
  * @param {*} slippageBps 滑点，1 就是 0.01%（万分之一）的滑点
  */
 async function swap(inputMint, outputMint, amount, slippageBps) {
-    const quoteResponse = await (await fetch(`https://quote-api.jup.ag/v6/quote?inputMint=${inputMint}&outputMint=${outputMint}&amount=${amount}&slippageBps=${slippageBps}`)).json();
+    const quoteResponse = await (await fetch(`https://public.jupiterapi.com?inputMint=${inputMint}&outputMint=${outputMint}&amount=${amount}&slippageBps=${slippageBps}`)).json();
     console.log(quoteResponse);
 
     // get serialized transactions for the swap
     const { swapTransaction } = await (
-        await fetch('https://quote-api.jup.ag/v6/swap', {
+        await fetch('https://public.jupiterapi.com/swap', {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json'


### PR DESCRIPTION
This PR adjusts the API constants provided for the jupiter package. The default API was updated for swap/quote to leverage [jupiterapi.com](https://www.jupiterapi.com/). The API offers higher rate limits along with a faster updated market cache. The [jupiterapi.com](https://www.jupiterapi.com/) market cache surfaces newly launched tokens faster since it doesn't require a certain volume/liquidity threshold to be met, along with an improved cadence of it being updated. With that said, the API does take a small platform fee (0.2%) on swaps given the stability/rate limits/new markets it provides. More details can be found on their site.